### PR TITLE
Update navigation_reader (_tocFileEntryPath)

### DIFF
--- a/lib/src/readers/navigation_reader.dart
+++ b/lib/src/readers/navigation_reader.dart
@@ -158,10 +158,14 @@ class NavigationReader {
             'EPUB parsing error: TOC file $_tocFileEntryPath not found in archive.');
       }
       //Get relative toc file path
-      _tocFileEntryPath = ((_tocFileEntryPath!.split('/')..removeLast())
-                ..removeAt(0))
-              .join('/') +
-          '/';
+      if (_tocFileEntryPath!.contains('/')) {
+        _tocFileEntryPath = ((_tocFileEntryPath!.split('/')..removeLast())
+                  ..removeAt(0))
+                .join('/') +
+            '/';
+      } else {
+        _tocFileEntryPath = '';
+      }
 
       var containerDocument =
           xml.XmlDocument.parse(convert.utf8.decode(tocFileEntry.content));


### PR DESCRIPTION
Check if _tocFileEntryPath contains '/' before splitting and removing from list.

If we didn't check, this will throw RangeError because there is only one item in list.