### PR TITLE
utils: normalize zip file path

### DIFF
--- a/lib/src/utils/zip_path_utils.dart
+++ b/lib/src/utils/zip_path_utils.dart
@@ -9,10 +9,12 @@ class ZipPathUtils {
   }
 
   static String? combine(String? directory, String? fileName) {
+    var path;
     if (directory == null || directory == '') {
-      return fileName;
+      path = fileName;
     } else {
-      return directory + '/' + fileName!;
+      path = directory + '/' + fileName!;
     }
+    return Uri.parse(path).normalizePath().path;
   }
 }


### PR DESCRIPTION
It is possible for a link to use a relative path and thus have `..` within it.

In such a scenario, the current implementation will throw an error file not found because it simply performs string comparison against the absolute path, e.g., because `a/b/../c` is considered different from `a/c`.

This PR updates `ZipPathUtils.combine` to always normalize the path.
