### PR TITLE
handle accented filenames on internal files

### DIFF
--- a/lib/src/readers/chapter_reader.dart
+++ b/lib/src/readers/chapter_reader.dart
@@ -3,6 +3,8 @@ import '../ref_entities/epub_chapter_ref.dart';
 import '../ref_entities/epub_text_content_file_ref.dart';
 import '../schema/navigation/epub_navigation_point.dart';
 
+import 'content_reader.dart';
+
 class ChapterReader {
   static List<EpubChapterRef> getChapters(EpubBookRef bookRef) {
     if (bookRef.Schema!.Navigation == null) {
@@ -16,10 +18,10 @@ class ChapterReader {
       EpubBookRef bookRef, List<EpubNavigationPoint> navigationPoints) {
     var result = <EpubChapterRef>[];
     // navigationPoints.forEach((EpubNavigationPoint navigationPoint) {
-    for (var navigationPoint in navigationPoints){
+    for (var navigationPoint in navigationPoints) {
       String? contentFileName;
       String? anchor;
-      if (navigationPoint.Content?.Source ==null) continue;
+      if (navigationPoint.Content?.Source == null) continue;
       var contentSourceAnchorCharIndex =
           navigationPoint.Content!.Source!.indexOf('#');
       if (contentSourceAnchorCharIndex == -1) {
@@ -31,7 +33,7 @@ class ChapterReader {
         anchor = navigationPoint.Content!.Source!
             .substring(contentSourceAnchorCharIndex + 1);
       }
-      contentFileName = Uri.decodeFull(contentFileName!);
+      contentFileName = accentedFileChecker(contentFileName!);
       EpubTextContentFileRef? htmlContentFileRef;
       if (!bookRef.Content!.Html!.containsKey(contentFileName)) {
         throw Exception(
@@ -47,7 +49,8 @@ class ChapterReader {
           getChaptersImpl(bookRef, navigationPoint.ChildNavigationPoints!);
 
       result.add(chapterRef);
-    };
+    }
+    ;
     return result;
   }
 }

--- a/lib/src/readers/content_reader.dart
+++ b/lib/src/readers/content_reader.dart
@@ -6,6 +6,29 @@ import '../ref_entities/epub_content_ref.dart';
 import '../ref_entities/epub_text_content_file_ref.dart';
 import '../schema/opf/epub_manifest_item.dart';
 
+//Accented characters throw a Invalid argument(s): Illegal percent encoding in URI on Uri.decodeFull. 
+//By checking if it throws an error and returning the filename again if so, you can use accented chars in
+//epub internal filenames. 
+String accentedFileChecker(String incomingFileName) {
+  bool errorThrown = false;
+  String fileName = '';
+  String decodedFileName = '';
+
+  try {
+    decodedFileName = Uri.decodeFull(incomingFileName);
+  } catch (e) {
+    errorThrown = true;
+  } finally {
+    if (errorThrown) {
+      fileName = incomingFileName;
+    } else {
+      fileName = decodedFileName;
+    }
+  }
+  return fileName;
+}
+//////
+
 class ContentReader {
   static EpubContentRef parseContentMap(EpubBookRef bookRef) {
     var result = EpubContentRef();
@@ -30,7 +53,7 @@ class ContentReader {
         case EpubContentType.DTBOOK_NCX:
           var epubTextContentFile = EpubTextContentFileRef(bookRef);
           {
-            epubTextContentFile.FileName = Uri.decodeFull(fileName!);
+            epubTextContentFile.FileName = accentedFileChecker(fileName!);
             epubTextContentFile.ContentMimeType = contentMimeType;
             epubTextContentFile.ContentType = contentType;
           }
@@ -62,7 +85,7 @@ class ContentReader {
         default:
           var epubByteContentFile = EpubByteContentFileRef(bookRef);
           {
-            epubByteContentFile.FileName = Uri.decodeFull(fileName!);
+            epubByteContentFile.FileName = accentedFileChecker(fileName!);
             epubByteContentFile.ContentMimeType = contentMimeType;
             epubByteContentFile.ContentType = contentType;
           }


### PR DESCRIPTION
I had trouble with epubx handling a book and tracked it down to accented characters in the internal filenames. 

See this screenshot of the internal filenames inside the file. 

<img width="415" alt="Screenshot 2023-10-05 at 2 06 05 PM" src="https://github.com/ScerIO/epubx.dart/assets/58198267/ea709c0b-c5f9-4385-aff6-0f027e8a64e7">

The problem is that the filenames are sent through Uri.decodeFull(), which throws an

`Invalid argument(s): Illegal percent encoding in URI` 

on encountering an accent. 

I put some code in that checked for the error and if there was an error on Uri.decodeFull returns the fileName with no change. 

The problem with what I added is that it does not cover the case that you have accented chars and encoded url filenames, but I thought it could be a start of something eventually useful. It is covering me on these filenames which do have accents but no spaces etc that Uri.decodeFull() helps with. 