### PR TITLE
fix: Check if cover image is null before null check operator

### DIFF
--- a/lib/src/entities/epub_book.dart
+++ b/lib/src/entities/epub_book.dart
@@ -40,8 +40,9 @@ class EpubBook {
         collections.listsEqual(AuthorList, other.AuthorList) &&
         Schema == other.Schema &&
         Content == other.Content &&
-        collections.listsEqual(
-            CoverImage!.getBytes(), other.CoverImage!.getBytes()) &&
+        ((CoverImage == null && other.CoverImage == null) ||
+            (collections.listsEqual(
+                CoverImage!.getBytes(), other.CoverImage!.getBytes()))) &&
         collections.listsEqual(Chapters, other.Chapters);
   }
 }


### PR DESCRIPTION
Fixes [tanoargie/epubx.dart#100](https://github.com/tanoargie/epubx.dart/issues/1#issue-2080508974)