### PR TITLE
Fixed manifest writer to include properties attribute.

### DIFF
--- a/lib/src/writers/epub_manifest_writer.dart
+++ b/lib/src/writers/epub_manifest_writer.dart
@@ -10,6 +10,9 @@ class EpubManifestWriter {
             ..attribute('id', item.Id!)
             ..attribute('href', item.Href!)
             ..attribute('media-type', item.MediaType!);
+            if (item.Properties != null) {
+              builder.attribute('properties', item.Properties);
+            }
         });
       });
     });


### PR DESCRIPTION
After writing an epub, the manifest would end up with a `#nav` item which lacked a `properties` attribute. That is, the manifest item

`<item href="nav.xhtml" id="nav" media-type="application/xhtml+xml" properties="nav"/>`

would be written as

`<item id="nav" href="nav.xhtml" media-type="application/xhtml+xml"/>`

This is problematic as the manifest reader uses that attribute to identify the nav item, preventing a written book from being read again (an exception would be thrown if reading was attempted). This change ensures that the `properties` attribute is written to each manifest element if it has a value, resolving this problem.